### PR TITLE
fixed unlinked symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ wget -O /pixelmon/mods/Pixelmon-server.jar https://download.nodecdn.net/containe
 cd /pixelmon && \
 echo eula=true > eula.txt && \
 java -jar forge-installer.jar --installServer && \
-ln -s forge-1.12.2-14.23.5.2854-universal.jar forge.jar && \
+ln -s forge-1.12.2-14.23.5.2854*.jar forge.jar && \
 rm -f forge-installer.jar && \
 echo \#\!/bin/sh > /pixelmon/start-server.sh && \
 echo cd '"$(dirname "$(readlink -fn "$0")")"' >> /pixelmon/start-server.sh && \


### PR DESCRIPTION
Maybe the name changed from "-universal.jar" to just ".jar"
I changed it to a wildcard so if it changes sometimes back to universal it will still work.
This was causing a bug that the symlink was broken:
```
/pixelmon # ls -lha
total 33928
drwxr-xr-x    4 root     root        4.0K Nov  6 10:54 .
drwxr-xr-x    1 root     root        4.0K Nov  6 10:54 ..
-rw-r--r--    1 root     root       18.7K Jul  2 16:10 1.12.2.json
-rw-r--r--    1 root     root          10 Jul  2 16:10 eula.txt
-rw-r--r--    1 root     root        4.3M Jul  2 16:10 forge-1.12.2-14.23.5.2854.jar
-rw-r--r--    1 root     root        5.0K Jul  2 16:10 forge-installer.jar.log
lrwxrwxrwx    1 root     root          39 Jul  2 16:10 forge.jar -> forge-1.12.2-14.23.5.2854-universal.jar
drwxr-xr-x    7 root     root        4.0K Nov  6 10:54 libraries
-rw-r--r--    1 root     root       28.8M Jul  2 16:10 minecraft_server.1.12.2.jar
drwxr-xr-x    2 root     root        4.0K Nov  6 10:54 mods
-rwxr-xr-x    1 root     root          83 Jul  2 16:10 start-server.sh
```